### PR TITLE
fix(tests): no integration test on /verify endpoint

### DIFF
--- a/src/verify/index.js
+++ b/src/verify/index.js
@@ -1,6 +1,6 @@
 const middy = require("middy");
 const { cors } = require("middy/middlewares");
-const verify = require("@govtechsg/oa-verify");
+const { verify } = require("@govtechsg/oa-verify");
 const config = require("./config");
 
 const handleVerify = async (event, _context, callback) => {

--- a/test/e2e/verify.integration.test.js
+++ b/test/e2e/verify.integration.test.js
@@ -1,6 +1,7 @@
 const supertest = require("supertest");
 const ropstenDocument = require("../fixtures/certificate.json");
 const mainnetDocument = require("../fixtures/certificateMainnetValid.json");
+const { unissuedResponse, successfulResponse } = require("../utils/matchers");
 
 const API_ENDPOINT = "https://api-ropsten.opencerts.io";
 const request = supertest(API_ENDPOINT);
@@ -17,30 +18,7 @@ describe("verify", () => {
       .expect("Content-Type", /json/)
       .expect(200)
       .expect(res => {
-        expect(res.body).toEqual({
-          hash: {
-            checksumMatch: true
-          },
-          issued: {
-            issuedOnAll: true,
-            details: [
-              {
-                address: "0xc36484efa1544c32ffed2e80a1ea9f0dfc517495",
-                issued: true
-              }
-            ]
-          },
-          revoked: {
-            revokedOnAny: false,
-            details: [
-              {
-                address: "0xc36484efa1544c32ffed2e80a1ea9f0dfc517495",
-                revoked: false
-              }
-            ]
-          },
-          valid: true
-        });
+        expect(res.body).toEqual(successfulResponse({ network: "ropsten" }));
       });
   }, 5000);
 
@@ -55,32 +33,7 @@ describe("verify", () => {
       .expect("Content-Type", /json/)
       .expect(200)
       .expect(res => {
-        expect(res.body).toEqual({
-          hash: {
-            checksumMatch: true
-          },
-          issued: {
-            issuedOnAll: false,
-            details: [
-              {
-                address: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-                error:
-                  'call exception (address="0x007d40224f6562461633ccfbaffd359ebb2fc9ba", method="isIssued(bytes32)", args=["0x1a040999254caaf7a33cba67ec6a9b862da1dacf8a0d1e3bb76347060fc615d6"], version=4.0.37)',
-                issued: false
-              }
-            ]
-          },
-          revoked: {
-            revokedOnAny: false,
-            details: [
-              {
-                address: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-                revoked: false
-              }
-            ]
-          },
-          valid: false
-        });
+        expect(res.body).toEqual(unissuedResponse({ network: "mainnet" }));
       });
   }, 5000);
 });

--- a/test/integration/verify.integration.test.js
+++ b/test/integration/verify.integration.test.js
@@ -1,6 +1,7 @@
 const supertest = require("supertest");
 const ropstenDocument = require("../fixtures/certificate.json");
 const mainnetDocument = require("../fixtures/certificateMainnetValid.json");
+const { unissuedResponse, successfulResponse } = require("../utils/matchers");
 
 const API_ENDPOINT = "http://localhost:3000";
 const request = supertest(API_ENDPOINT);
@@ -17,30 +18,7 @@ describe("verify", () => {
       .expect("Content-Type", /json/)
       .expect(200)
       .expect(res => {
-        expect(res.body).toEqual({
-          hash: {
-            checksumMatch: true
-          },
-          issued: {
-            issuedOnAll: true,
-            details: [
-              {
-                address: "0xc36484efa1544c32ffed2e80a1ea9f0dfc517495",
-                issued: true
-              }
-            ]
-          },
-          revoked: {
-            revokedOnAny: false,
-            details: [
-              {
-                address: "0xc36484efa1544c32ffed2e80a1ea9f0dfc517495",
-                revoked: false
-              }
-            ]
-          },
-          valid: true
-        });
+        expect(res.body).toEqual(successfulResponse({ network: "ropsten" }));
       });
   }, 5000);
 
@@ -55,32 +33,7 @@ describe("verify", () => {
       .expect("Content-Type", /json/)
       .expect(200)
       .expect(res => {
-        expect(res.body).toEqual({
-          hash: {
-            checksumMatch: true
-          },
-          issued: {
-            issuedOnAll: false,
-            details: [
-              {
-                address: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-                error:
-                  'call exception (address="0x007d40224f6562461633ccfbaffd359ebb2fc9ba", method="isIssued(bytes32)", args=["0x1a040999254caaf7a33cba67ec6a9b862da1dacf8a0d1e3bb76347060fc615d6"], version=4.0.37)',
-                issued: false
-              }
-            ]
-          },
-          revoked: {
-            revokedOnAny: false,
-            details: [
-              {
-                address: "0x007d40224f6562461633ccfbaffd359ebb2fc9ba",
-                revoked: false
-              }
-            ]
-          },
-          valid: false
-        });
+        expect(res.body).toEqual(unissuedResponse({ network: "mainnet" }));
       });
   }, 5000);
 });

--- a/test/integration/verify.integration.test.js
+++ b/test/integration/verify.integration.test.js
@@ -2,7 +2,7 @@ const supertest = require("supertest");
 const ropstenDocument = require("../fixtures/certificate.json");
 const mainnetDocument = require("../fixtures/certificateMainnetValid.json");
 
-const API_ENDPOINT = "https://api-ropsten.opencerts.io";
+const API_ENDPOINT = "http://localhost:3000";
 const request = supertest(API_ENDPOINT);
 
 describe("verify", () => {

--- a/test/utils/matchers.js
+++ b/test/utils/matchers.js
@@ -1,0 +1,70 @@
+const ROPSTEN_ADDRESS = "0xc36484efa1544c32ffed2e80a1ea9f0dfc517495";
+const MAINNET_ADDRESS = "0x007d40224f6562461633ccfbaffd359ebb2fc9ba";
+
+const getIssuerAddress = network => {
+  switch (network.toLowerCase()) {
+    case "mainnet":
+      return MAINNET_ADDRESS;
+    case "ropsten":
+    default:
+      return ROPSTEN_ADDRESS;
+  }
+};
+
+const unissuedResponse = ({ network = "ropsten" }) => {
+  const documentStoreAddress = getIssuerAddress(network);
+  return expect.objectContaining({
+    hash: { checksumMatch: true },
+    issued: {
+      issuedOnAll: false,
+      details: [
+        {
+          address: documentStoreAddress,
+          error: expect.stringMatching("exception"),
+          issued: false
+        }
+      ]
+    },
+    revoked: {
+      revokedOnAny: false,
+      details: [
+        {
+          address: documentStoreAddress,
+          revoked: false
+        }
+      ]
+    },
+    valid: false
+  });
+};
+
+const successfulResponse = ({ network = "ropsten" }) => {
+  const documentStoreAddress = getIssuerAddress(network);
+  return expect.objectContaining({
+    hash: { checksumMatch: true },
+    issued: {
+      issuedOnAll: true,
+      details: [
+        {
+          address: documentStoreAddress,
+          issued: true
+        }
+      ]
+    },
+    revoked: {
+      revokedOnAny: false,
+      details: [
+        {
+          address: documentStoreAddress,
+          revoked: false
+        }
+      ]
+    },
+    valid: true
+  });
+};
+
+module.exports = {
+  successfulResponse,
+  unissuedResponse
+};


### PR DESCRIPTION
There was no integration test running against the /verify endpoint so I copied over the e2e test since it should be largely similar less the endpoint address

Also oa-verify was updated in the previous PR but test was not updated to reflect that.