### PR TITLE
feat: ttl on create

### DIFF
--- a/src/storage/create.js
+++ b/src/storage/create.js
@@ -4,8 +4,8 @@ const { uploadDocument } = require("./documentService");
 
 const handleCreate = async event => {
   try {
-    const { document } = JSON.parse(event.body);
-    const receipt = await uploadDocument(document);
+    const { document, ttl } = JSON.parse(event.body);
+    const receipt = await uploadDocument(document, ttl);
     return {
       statusCode: 200,
       body: JSON.stringify(receipt)

--- a/src/storage/createAtId.js
+++ b/src/storage/createAtId.js
@@ -4,9 +4,9 @@ const { uploadDocumentAtId } = require("./documentService");
 
 const handleCreateAtId = async event => {
   try {
-    const { document } = JSON.parse(event.body);
+    const { document, ttl } = JSON.parse(event.body);
     const { id } = event.pathParameters;
-    const receipt = await uploadDocumentAtId(document, id);
+    const receipt = await uploadDocumentAtId(document, id, ttl);
     return {
       statusCode: 200,
       body: JSON.stringify(receipt)

--- a/src/storage/documentService/documentService.js
+++ b/src/storage/documentService/documentService.js
@@ -50,7 +50,7 @@ const getDecryptionKey = async id => {
   return document;
 };
 
-const calculateAbsoluteTtl = ttlInMicroseconds =>
+const calculateExpiryTimestamp = ttlInMicroseconds =>
   Date.now() + ttlInMicroseconds;
 
 const uploadDocumentAtId = async (
@@ -79,7 +79,13 @@ const uploadDocumentAtId = async (
   );
 
   const { id } = await putDocument(
-    { cipherText, iv, tag, type, ttl: calculateAbsoluteTtl(ttlInMicroseconds) },
+    {
+      cipherText,
+      iv,
+      tag,
+      type,
+      ttl: calculateExpiryTimestamp(ttlInMicroseconds)
+    },
     documentId
   );
   return {
@@ -107,7 +113,13 @@ const uploadDocument = async (
   );
 
   const { id } = await putDocument(
-    { cipherText, iv, tag, type, ttl: calculateAbsoluteTtl(ttlInMicroseconds) },
+    {
+      cipherText,
+      iv,
+      tag,
+      type,
+      ttl: calculateExpiryTimestamp(ttlInMicroseconds)
+    },
     uuid()
   );
   return {
@@ -140,7 +152,7 @@ module.exports = {
   uploadDocument,
   uploadDocumentAtId,
   getDocument,
-  calculateAbsoluteTtl,
+  calculateExpiryTimestamp,
   DEFAULT_TTL_IN_MICROSECONDS,
   MAX_TTL_IN_MICROSECONDS
 };

--- a/src/storage/documentService/documentService.js
+++ b/src/storage/documentService/documentService.js
@@ -24,7 +24,11 @@ const getDocument = async (id, { cleanup } = { cleanup: false }) => {
   };
   const document = await get(params);
   // we throw this error because if awaitingUpload exists on an object, it also has a decryption key in it and we don't want to return that, ever
-  if (document.awaitingUpload) {
+  if (
+    !document ||
+    document.awaitingUpload ||
+    document.document.ttl < Date.now()
+  ) {
     throw new Error("No Document Found");
   }
   if (cleanup) {

--- a/src/storage/documentService/documentService.js
+++ b/src/storage/documentService/documentService.js
@@ -9,6 +9,7 @@ const config = require("../config");
 const { put, get, remove } = require("../s3");
 
 const DEFAULT_TTL = 30 * 24 * 60 * 60 * 1000;
+const MAX_TTL = 90 * 24 * 60 * 60 * 1000;
 
 const putDocument = async (document, id) => {
   const params = {
@@ -58,6 +59,10 @@ const uploadDocumentAtId = async (document, documentId, relativeTtl) => {
     throw new Error(`No placeholder file`);
   }
 
+  if (relativeTtl && relativeTtl > MAX_TTL) {
+    throw new Error("Ttl cannot exceed 90 days");
+  }
+
   const fragments = await verify(document, { network: config.network });
   if (!isValid(fragments)) {
     throw new Error("Document is not valid");
@@ -85,6 +90,10 @@ const uploadDocument = async (document, relativeTtl = DEFAULT_TTL) => {
   const fragments = await verify(document, { network: config.network });
   if (!isValid(fragments)) {
     throw new Error("Document is not valid");
+  }
+
+  if (relativeTtl > MAX_TTL) {
+    throw new Error("Ttl cannot exceed 90 days");
   }
 
   const { cipherText, iv, tag, key, type } = await encryptString(
@@ -126,5 +135,6 @@ module.exports = {
   uploadDocumentAtId,
   getDocument,
   calculateAbsoluteTtl,
-  DEFAULT_TTL
+  DEFAULT_TTL,
+  MAX_TTL
 };

--- a/src/storage/documentService/documentService.js
+++ b/src/storage/documentService/documentService.js
@@ -125,5 +125,6 @@ module.exports = {
   uploadDocument,
   uploadDocumentAtId,
   getDocument,
-  calculateAbsoluteTtl
+  calculateAbsoluteTtl,
+  DEFAULT_TTL
 };

--- a/src/storage/documentService/documentService.js
+++ b/src/storage/documentService/documentService.js
@@ -69,7 +69,9 @@ const uploadDocumentAtId = async (document, documentId, relativeTtl) => {
   );
 
   const { id } = await putDocument(
-    { cipherText, iv, tag, type, ttl: calculateAbsoluteTtl(relativeTtl) },
+    relativeTtl
+      ? { cipherText, iv, tag, type, ttl: calculateAbsoluteTtl(relativeTtl) }
+      : { cipherText, iv, tag, type },
     documentId
   );
   return {

--- a/src/storage/documentService/documentService.js
+++ b/src/storage/documentService/documentService.js
@@ -43,6 +43,8 @@ const getDecryptionKey = async id => {
   return document;
 };
 
+const calculateAbsoluteTtl = relativeTtl => Date.now() + relativeTtl;
+
 const uploadDocumentAtId = async (
   document,
   documentId,
@@ -72,8 +74,8 @@ const uploadDocumentAtId = async (
   };
 };
 
-const uploadDocument = async (document, network = config.network) => {
-  const fragments = await verify(document, { network });
+const uploadDocument = async (document, relativeTtl) => {
+  const fragments = await verify(document, { network: config.network });
   if (!isValid(fragments)) {
     throw new Error("Document is not valid");
   }
@@ -82,7 +84,10 @@ const uploadDocument = async (document, network = config.network) => {
     JSON.stringify(document)
   );
 
-  const { id } = await putDocument({ cipherText, iv, tag, type }, uuid());
+  const { id } = await putDocument(
+    { cipherText, iv, tag, type, ttl: calculateAbsoluteTtl(relativeTtl) },
+    uuid()
+  );
   return {
     id,
     key,
@@ -112,5 +117,6 @@ module.exports = {
   getQueueNumber,
   uploadDocument,
   uploadDocumentAtId,
-  getDocument
+  getDocument,
+  calculateAbsoluteTtl
 };

--- a/src/storage/documentService/documentService.test.js
+++ b/src/storage/documentService/documentService.test.js
@@ -1,0 +1,9 @@
+const { calculateAbsoluteTtl } = require("./documentService");
+
+jest.spyOn(Date, "now").mockImplementation(() => 1578897000000);
+
+describe("calculateAbsoluteTtl", () => {
+  it("should return the absolute timestamp given a relative ttl", () => {
+    expect(calculateAbsoluteTtl(24 * 60 * 60 * 1000)).toBe(1578983400000);
+  });
+});

--- a/src/storage/documentService/documentService.test.js
+++ b/src/storage/documentService/documentService.test.js
@@ -1,9 +1,42 @@
-const { calculateAbsoluteTtl } = require("./documentService");
+const { calculateAbsoluteTtl, getDocument } = require("./documentService");
+const { get } = require("../s3");
 
+jest.mock("../s3");
 jest.spyOn(Date, "now").mockImplementation(() => 1578897000000);
 
 describe("calculateAbsoluteTtl", () => {
   it("should return the absolute timestamp given a relative ttl", () => {
     expect(calculateAbsoluteTtl(24 * 60 * 60 * 1000)).toBe(1578983400000);
+  });
+});
+
+describe("getDocument", () => {
+  it("should throw No Document Found if document has expired", async () => {
+    const invalidDocument = {
+      document: {
+        cipherText: "MOCK_CIPHERTEXT",
+        iv: "MOCK_IV",
+        tag: "MOCK_TAG",
+        type: "OPEN-ATTESTATION-TYPE-1",
+        ttl: 1478983400000
+      }
+    };
+    get.mockResolvedValue(invalidDocument);
+    await expect(getDocument("ID")).rejects.toThrow("No Document Found");
+  });
+
+  it("should return document if document is found and has not expired", async () => {
+    const validDocument = {
+      document: {
+        cipherText: "MOCK_CIPHERTEXT",
+        iv: "MOCK_IV",
+        tag: "MOCK_TAG",
+        type: "OPEN-ATTESTATION-TYPE-1",
+        ttl: 1578983400000
+      }
+    };
+    get.mockResolvedValue(validDocument);
+    const result = await getDocument("ID");
+    expect(result).toEqual(validDocument);
   });
 });

--- a/src/storage/documentService/documentService.test.js
+++ b/src/storage/documentService/documentService.test.js
@@ -1,12 +1,12 @@
-const { calculateAbsoluteTtl, getDocument } = require("./documentService");
+const { calculateExpiryTimestamp, getDocument } = require("./documentService");
 const { get } = require("../s3");
 
 jest.mock("../s3");
 jest.spyOn(Date, "now").mockImplementation(() => 1578897000000);
 
-describe("calculateAbsoluteTtl", () => {
+describe("calculateExpiryTimestamp", () => {
   it("should return the absolute timestamp given a relative ttl", () => {
-    expect(calculateAbsoluteTtl(24 * 60 * 60 * 1000)).toBe(1578983400000);
+    expect(calculateExpiryTimestamp(24 * 60 * 60 * 1000)).toBe(1578983400000);
   });
 });
 

--- a/test/integration/storage.integration.test.js
+++ b/test/integration/storage.integration.test.js
@@ -8,7 +8,8 @@ const {
   uploadDocumentAtId,
   getDocument,
   getQueueNumber,
-  DEFAULT_TTL
+  DEFAULT_TTL,
+  MAX_TTL
 } = require("../../src/storage/documentService");
 
 const {
@@ -62,6 +63,13 @@ describe("uploadDocument", () => {
       getResults.document.ttl < Date.now() + DEFAULT_TTL + TIME_SKEW_ALLOWANCE
     ).toBe(true);
     expect(getResults).toMatchObject(thatIsRetrievedDocument);
+  });
+
+  it("should throw error when ttl value > MAX_TLL", async () => {
+    isValid.mockReturnValueOnce(true);
+    const document = { foo: "bar" };
+    const uploaded = uploadDocument(document, MAX_TTL + 1);
+    await expect(uploaded).rejects.toThrow("Ttl cannot exceed 90 days");
   });
 });
 
@@ -131,6 +139,14 @@ describe("uploadDocumentAtId", () => {
     const getResults = await getDocument(uploaded.id);
     expect(getResults.document.ttl).toBeUndefined();
     expect(getResults).toMatchObject(thatIsRetrievedDocument);
+  });
+
+  it("should throw error when ttl value > MAX_TLL", async () => {
+    isValid.mockReturnValueOnce(true);
+    const document = { foo: "bar" };
+    const { id: queueNumber } = await getQueueNumber();
+    const uploaded = uploadDocumentAtId(document, queueNumber, MAX_TTL + 1);
+    await expect(uploaded).rejects.toThrow("Ttl cannot exceed 90 days");
   });
 });
 

--- a/test/integration/storage.integration.test.js
+++ b/test/integration/storage.integration.test.js
@@ -17,7 +17,7 @@ const {
 } = require("../utils/matchers");
 
 // TODO refactor those "integration" tests to NOT MOCK
-describe.only("uploadDocument", () => {
+describe("uploadDocument", () => {
   afterEach(() => {
     isValid.mockClear();
   });
@@ -36,9 +36,13 @@ describe.only("uploadDocument", () => {
     const uploaded = uploadDocument(document);
     await expect(uploaded).rejects.toThrow("Document is not valid");
   });
+
+  it("should allow user to specify ttl", () => {
+    throw new Error("Not implemented yet");
+  });
 });
 
-describe.only("uploadDocumentAtId", () => {
+describe("uploadDocumentAtId", () => {
   afterEach(() => {
     isValid.mockClear();
   });
@@ -81,9 +85,13 @@ describe.only("uploadDocumentAtId", () => {
     const uploaded = uploadDocumentAtId(document, queueNumber);
     await expect(uploaded).rejects.toThrow("Document is not valid");
   });
+
+  it("should allow user to specify ttl", () => {
+    throw new Error("Not implemented yet");
+  });
 });
 
-describe.only("getDocument", () => {
+describe("getDocument", () => {
   afterEach(() => {
     isValid.mockClear();
   });
@@ -117,14 +125,14 @@ describe.only("getDocument", () => {
   });
 });
 
-describe.only("getQueueNumber", () => {
+describe("getQueueNumber", () => {
   it("should return a placeholder object", async () => {
     const queueNumber = await getQueueNumber();
     expect(queueNumber).toMatchObject(thatIsAQueueNumber);
   });
 });
 
-describe.only("documentService", () => {
+describe("documentService", () => {
   afterEach(() => {
     isValid.mockClear();
   });

--- a/test/utils/matchers.js
+++ b/test/utils/matchers.js
@@ -16,6 +16,15 @@ const thatIsRetrievedDocument = {
   })
 };
 
+const thatIsRetrievedDocumentWithTtl = {
+  document: expect.objectContaining({
+    cipherText: expect.any(String),
+    iv: expect.any(String),
+    tag: expect.any(String),
+    ttl: expect.any(Number)
+  })
+};
+
 const thatIsAQueueNumber = {
   key: expect.any(String),
   id: expect.stringMatching(uuidV4Regex)
@@ -23,6 +32,7 @@ const thatIsAQueueNumber = {
 
 module.exports = {
   thatIsRetrievedDocument,
+  thatIsRetrievedDocumentWithTtl,
   thatIsUploadResponse,
   thatIsAQueueNumber
 };


### PR DESCRIPTION
Changes:
- Added TTL support for document storage
- Added default TTL (30 days) to `uploadDocument`
- `getDocument` to throw if document has ttl in the past
- Removed network parameter (should be taken from config instead of function args)
- Added test to incremental changes (did not test previous code that were untested)
- Added max ttl of 90 days

Also on AWS S3:
- Added rule to delete all object after 90 days

To be done in another PR:
- Batch function to delete all document with TTL in the past, using s3.select (SQL query)

Ps. `uploadDocumentAtId` does not have default ttl since it's usually used for long term storage
